### PR TITLE
Replace deprecated module SofaComponentAll by Sofa.Component

### DIFF
--- a/sofagym/envs/BubbleMotion/BubbleMotionToolbox.py
+++ b/sofagym/envs/BubbleMotion/BubbleMotionToolbox.py
@@ -22,7 +22,7 @@ import pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/CTR/CTRScene.py
+++ b/sofagym/envs/CTR/CTRScene.py
@@ -23,7 +23,7 @@ from splib3.animation import AnimationManagerController
 from CTRToolbox import RewardShaper, GoalSetter
 
 # Register all the common component in the factory.
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 path = dirname(abspath(__file__)) + '/'
 

--- a/sofagym/envs/CTR/CTRToolbox.py
+++ b/sofagym/envs/CTR/CTRToolbox.py
@@ -17,7 +17,7 @@ import SofaRuntime
 from splib3.animation.animate import Animation
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class RewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/CartStem/CartStemToolbox.py
+++ b/sofagym/envs/CartStem/CartStemToolbox.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/CartStemContact/CartStemContactToolbox.py
+++ b/sofagym/envs/CartStemContact/CartStemContactToolbox.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/CatchTheObject/CatchTheObjectToolbox.py
+++ b/sofagym/envs/CatchTheObject/CatchTheObjectToolbox.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/Diamond/DiamondToolbox.py
+++ b/sofagym/envs/Diamond/DiamondToolbox.py
@@ -17,7 +17,7 @@ import SofaRuntime
 from splib3.animation.animate import Animation
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/Gripper/GripperScene.py
+++ b/sofagym/envs/Gripper/GripperScene.py
@@ -18,7 +18,7 @@ from Gripper import Gripper
 
 path = os.path.dirname(os.path.abspath(__file__))+'/mesh/'
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 def add_plugins(root):

--- a/sofagym/envs/Gripper/GripperToolbox.py
+++ b/sofagym/envs/Gripper/GripperToolbox.py
@@ -22,7 +22,7 @@ from GripperTools import rewardShaper, goalSetter, _getGoalPos, getState, getRew
     getRotationCenter, translateFingers, rotateFingers, displace, getPos, setPos
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 def startCmd(root, action, duration):

--- a/sofagym/envs/Gripper/GripperTools.py
+++ b/sofagym/envs/Gripper/GripperTools.py
@@ -17,7 +17,7 @@ from math import cos, sin
 import numpy as np
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/Maze/MazeToolbox.py
+++ b/sofagym/envs/Maze/MazeToolbox.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
 from MazeTools import Graph, dijkstra
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/Maze/MazeTools.py
+++ b/sofagym/envs/Maze/MazeTools.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 
 import SofaRuntime
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class Graph:

--- a/sofagym/envs/MultiGaitRobot/MultiGaitRobotToolbox.py
+++ b/sofagym/envs/MultiGaitRobot/MultiGaitRobotToolbox.py
@@ -17,7 +17,7 @@ import Sofa.Simulation
 import SofaRuntime
 from splib3.animation.animate import Animation
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 CENTER_PRESSUR = 2000  # 3500
 LEG_PRESSUR = 1500  # 2000

--- a/sofagym/envs/SimpleMaze/MazeTools.py
+++ b/sofagym/envs/SimpleMaze/MazeTools.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 
 import SofaRuntime
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class Graph:

--- a/sofagym/envs/SimpleMaze/SimpleMazeToolbox.py
+++ b/sofagym/envs/SimpleMaze/SimpleMazeToolbox.py
@@ -26,7 +26,7 @@ from splib3.numerics import Quat
 from MazeTools import Graph, dijkstra
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 def addRigidObject(node, filename, collisionFilename=None, position=[0,0,0,0,0,0,1], scale=[1,1,1], textureFilename='', color=[1,1,1], density=0.002, name='Object', withSolver=True, collisionGroup = 0, withCollision=True):
 

--- a/sofagym/envs/StemPendulum/StemPendulumToolbox.py
+++ b/sofagym/envs/StemPendulum/StemPendulumToolbox.py
@@ -26,7 +26,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 from sofagym.utils import express_point
 
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 class rewardShaper(Sofa.Core.Controller):
     """Compute the reward.

--- a/sofagym/envs/Trunk/TrunkToolbox.py
+++ b/sofagym/envs/Trunk/TrunkToolbox.py
@@ -16,7 +16,7 @@ import Sofa.Simulation
 import SofaRuntime
 from splib.animation.animate import Animation
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/envs/TrunkCup/TrunkCupToolbox.py
+++ b/sofagym/envs/TrunkCup/TrunkCupToolbox.py
@@ -16,7 +16,7 @@ import Sofa.Simulation
 import SofaRuntime
 from splib.animation.animate import Animation
 
-SofaRuntime.importPlugin("SofaComponentAll")
+SofaRuntime.importPlugin("Sofa.Component")
 
 
 class rewardShaper(Sofa.Core.Controller):

--- a/sofagym/simulate.py
+++ b/sofagym/simulate.py
@@ -45,7 +45,7 @@ def init_simulation(config, _startCmd=None, mode="simu_and_visu"):
 
     # Load the scene
     root = Sofa.Core.Node("root")
-    SofaRuntime.importPlugin("SofaComponentAll")
+    SofaRuntime.importPlugin("Sofa.Component")
     create_scene(root,  config, mode = mode)
     Sofa.Simulation.init(root)
 


### PR DESCRIPTION
Because: https://github.com/sofa-framework/sofa/wiki/SOFA-NG:-documentation-on-transition#collection
This is one step closer of being able to use SofaGym without the compatibility layer of Sofa-NG