### PR TITLE
Fix Diamond env plugin requirement

### DIFF
--- a/sofagym/envs/Diamond/DiamondScene.py
+++ b/sofagym/envs/Diamond/DiamondScene.py
@@ -58,7 +58,8 @@ def createScene(rootNode, config=DEFAULT_CONFIG, mode='simu_and_visu'):
                                                                          'SofaSparseSolver',
                                                                          'SofaLoader',
                                                                          'SofaEngine',
-                                                                         'SofaConstraint'])
+                                                                         'SofaConstraint',
+                                                                         'Sofa.GL.Component.Shader'])
 
     source = config["source"]
     target = config["target"]


### PR DESCRIPTION
The Diamond scene uses ```LightManager```, which is in the ```Sofa.GL.Component.Shader``` plugin. So, I added it to the required plugins.