### PR TITLE
envs modifications

### DIFF
--- a/sofagym/envs/BubbleMotion/BubbleMotionEnv.py
+++ b/sofagym/envs/BubbleMotion/BubbleMotionEnv.py
@@ -76,13 +76,12 @@ class BubbleMotionEnv(AbstractEnv):
             client_<scene>Env.py.
 
         """
-
-
         super().reset()
 
         self.config.update({'goalPos': self.goal})
         obs = start_scene(self.config, self.nb_actions)
-        return obs['observation']
+        
+        return np.array(obs['observation'])
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/BubbleMotion/BubbleMotionToolbox.py
+++ b/sofagym/envs/BubbleMotion/BubbleMotionToolbox.py
@@ -14,7 +14,7 @@ import Sofa
 import Sofa.Core
 import Sofa.Simulation
 import SofaRuntime
-from splib.animation.animate import Animation
+from splib3.animation.animate import Animation
 
 import sys
 import pathlib
@@ -264,10 +264,10 @@ def startCmd(root, actions, duration):
 
     """
     incr = action_to_command(actions, root, duration/root.dt.value + 1)
-    startCmd_StemPendulum(root, incr, duration)
+    startCmd_BubbleMotion(root, incr, duration)
 
 
-def startCmd_StemPendulum(rootNode, incr, duration):
+def startCmd_BubbleMotion(rootNode, incr, duration):
     """Initialize the command.
 
     Parameters:
@@ -294,4 +294,4 @@ def startCmd_StemPendulum(rootNode, incr, duration):
             onUpdate=executeAnimation,
             params={"rootNode": rootNode,
                     "incr": incr},
-            duration=duration, mode="once", realTimeClock=False))
+            duration=duration, mode="once"))

--- a/sofagym/envs/CTR/CTREnv.py
+++ b/sofagym/envs/CTR/CTREnv.py
@@ -105,7 +105,7 @@ class ConcentricTubeRobotEnv(AbstractEnv):
         self.step(8)
         self.render()
 
-        return obs['observation']
+        return np.array(obs['observation'])
 
     def render(self, mode='rgb_array'):
         """See the current state of the environment.

--- a/sofagym/envs/CTR/CTRToolbox.py
+++ b/sofagym/envs/CTR/CTRToolbox.py
@@ -302,7 +302,7 @@ def start_cmd(rootNode, IRC_node, source, target, duration, instrument=0):
                     "anim_source": source,
                     "anim_target": target,
                     "anim_instrument": instrument},
-            duration=duration, mode="once"))#, realTimeClock=False))
+            duration=duration, mode="once"))
 
     return
 

--- a/sofagym/envs/CartStem/CartStemEnv.py
+++ b/sofagym/envs/CartStem/CartStemEnv.py
@@ -81,10 +81,10 @@ class CartStemEnv(AbstractEnv):
         super().reset()
 
         self.config.update({'init_x': -(self.config["max_move"]/8) + (self.config["max_move"]/4)*np.random.random()})
-
         self.config.update({'goalPos': self.goal})
 
         obs = start_scene(self.config, self.nb_actions)
+        
         return np.array(obs['observation'])
 
     def get_available_actions(self):

--- a/sofagym/envs/CartStemContact/CartStemContactEnv.py
+++ b/sofagym/envs/CartStemContact/CartStemContactEnv.py
@@ -93,8 +93,7 @@ class CartStemContactEnv(AbstractEnv):
         self.config.update({'goalList': [[x_goal, 0, 20]]})
         self.config.update({'max_move': max(abs(low_cube-1), high_cube+1)})
         self.config.update({'goalPos': self.goal})
-        # obs = super().reset()
-        # return np.array(obs)
+
         obs = start_scene(self.config, self.nb_actions)
 
         return np.array(obs['observation'])

--- a/sofagym/envs/Diamond/DiamondEnv.py
+++ b/sofagym/envs/Diamond/DiamondEnv.py
@@ -85,7 +85,7 @@ class DiamondRobotEnv(AbstractEnv):
             self.viewer.reset()
         self.render()
 
-        return obs['observation']
+        return np.array(obs['observation'])
 
     def render(self, mode='rgb_array'):
         """See the current state of the environment.

--- a/sofagym/envs/Diamond/DiamondToolbox.py
+++ b/sofagym/envs/Diamond/DiamondToolbox.py
@@ -298,7 +298,7 @@ def startCmd_Diamond(root, displacement, duration):
             params={"root": root,
                     "displacement": displacement,
                     "n_steps": duration},
-            duration=duration, mode="once"))#, realTimeClock=False
+            duration=duration, mode="once"))
 
 
 def action_to_command(action):

--- a/sofagym/envs/Gripper/GripperEnv.py
+++ b/sofagym/envs/Gripper/GripperEnv.py
@@ -78,7 +78,7 @@ class GripperEnv(AbstractEnv):
         obs = start_scene(self.config, self.nb_actions)
         info = {}
 
-        return (obs['observation'], info)
+        return (np.array(obs['observation']), info)
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/Gripper/GripperToolbox.py
+++ b/sofagym/envs/Gripper/GripperToolbox.py
@@ -9,7 +9,7 @@ __copyright__ = "(c) 2020, Inria"
 __date__ = "Oct 7 2020"
 
 import SofaRuntime
-from splib.animation.animate import Animation
+from splib3.animation.animate import Animation
 
 import sys
 import pathlib
@@ -83,7 +83,7 @@ def startCmd_Gripper(rootNode, fingers, rotation, direction, displacement, durat
                     "rotation": rotation,
                     "direction": direction,
                     "displacement": displacement},
-            duration=duration, mode="once", realTimeClock=False))
+            duration=duration, mode="once"))
 
 
 def action_to_command(action):

--- a/sofagym/envs/Maze/MazeEnv.py
+++ b/sofagym/envs/Maze/MazeEnv.py
@@ -76,7 +76,7 @@ class MazeEnv(AbstractEnv):
         self.config.update({'goalPos': self.goal})
         obs = start_scene(self.config, self.nb_actions)
 
-        return obs['observation']
+        return np.array(obs['observation'])
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/Maze/MazeToolbox.py
+++ b/sofagym/envs/Maze/MazeToolbox.py
@@ -14,7 +14,7 @@ import Sofa
 import Sofa.Core
 import Sofa.Simulation
 import SofaRuntime
-from splib.animation.animate import Animation
+from splib3.animation.animate import Animation
 
 import sys
 import pathlib
@@ -346,7 +346,7 @@ def startCmd_Maze(rootNode, actuator, displacement, duration):
     # Add animation in the scene
     rootNode.AnimationManager.addAnimation(
         Animation(onUpdate=executeAnimation, params={"actuator": actuator, "displacement": displacement},
-                  duration=duration, mode="once", realTimeClock=False))
+                  duration=duration, mode="once"))
 
 
 def action_to_command(action):

--- a/sofagym/envs/SimpleMaze/SimpleMazeEnv.py
+++ b/sofagym/envs/SimpleMaze/SimpleMazeEnv.py
@@ -84,7 +84,7 @@ class SimpleMazeEnv(AbstractEnv):
             self.viewer.reset()
         self.render()
 
-        return obs['observation']
+        return np.array(obs['observation'])
 
     def render(self, mode='rgb_array'):
         """See the current state of the environment.

--- a/sofagym/envs/StemPendulum/StemPendulumToolbox.py
+++ b/sofagym/envs/StemPendulum/StemPendulumToolbox.py
@@ -15,7 +15,7 @@ import Sofa
 import Sofa.Core
 import Sofa.Simulation
 import SofaRuntime
-from splib.animation.animate import Animation
+from splib3.animation.animate import Animation
 
 import sys
 import pathlib
@@ -283,4 +283,4 @@ def startCmd_StemPendulum(rootNode, incr, duration):
             onUpdate=executeAnimation,
             params={"rootNode": rootNode,
                     "incr": incr},
-            duration=duration, mode="once", realTimeClock=False))
+            duration=duration, mode="once"))

--- a/sofagym/envs/Trunk/TrunkEnv.py
+++ b/sofagym/envs/Trunk/TrunkEnv.py
@@ -77,7 +77,7 @@ class TrunkEnv(AbstractEnv):
         self.config.update({'goalPos': self.goal})
         obs = start_scene(self.config, self.nb_actions)
 
-        return obs['observation']
+        return np.array(obs['observation'])
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/Trunk/TrunkScene.py
+++ b/sofagym/envs/Trunk/TrunkScene.py
@@ -5,11 +5,11 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
 
-from splib.animation import AnimationManagerController
+from splib3.animation import AnimationManagerController
 from math import cos, sin
 import numpy as np
-from splib.objectmodel import SofaPrefab, SofaObject
-from splib.numerics import Vec3, Quat
+from splib3.objectmodel import SofaPrefab, SofaObject
+from splib3.numerics import Vec3, Quat
 
 
 from TrunkToolbox import rewardShaper, goalSetter

--- a/sofagym/envs/Trunk/TrunkToolbox.py
+++ b/sofagym/envs/Trunk/TrunkToolbox.py
@@ -14,7 +14,7 @@ import Sofa
 import Sofa.Core
 import Sofa.Simulation
 import SofaRuntime
-from splib.animation.animate import Animation
+from splib3.animation.animate import Animation
 
 SofaRuntime.importPlugin("Sofa.Component")
 
@@ -324,7 +324,7 @@ def startCmd_Trunk(rootNode, cable, displacement, duration):
             onUpdate=executeAnimation,
             params={"cable": cable,
                     "displacement": displacement},
-            duration=duration, mode="once", realTimeClock=False))
+            duration=duration, mode="once"))
 
 
 def action_to_command(action):

--- a/sofagym/envs/TrunkCup/TrunkCupEnv.py
+++ b/sofagym/envs/TrunkCup/TrunkCupEnv.py
@@ -75,7 +75,7 @@ class TrunkCupEnv(AbstractEnv):
         self.config.update({'goalPos': self.goal})
         obs = start_scene(self.config, self.nb_actions)
 
-        return obs['observation']
+        return np.array(obs['observation'])
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/TrunkCup/TrunkCupScene.py
+++ b/sofagym/envs/TrunkCup/TrunkCupScene.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 from math import cos
 from math import sin
 import numpy as np
-from splib.animation import AnimationManagerController
+from splib3.animation import AnimationManagerController
 from TrunkCupToolbox import rewardShaper, goalSetter
 
 
@@ -256,7 +256,7 @@ def createScene(rootNode, config={"source": [-600.0, -25, 100], "target": [30, -
 	rootNode.addObject(goalSetter(name="GoalSetter", goalMO=goal_mo, goalPos = config['goalPos']))
 
 	if simu:
-		rootNode.addObject(AnimationManagerController(name="AnimationManager"))
+		rootNode.addObject(AnimationManagerController(rootNode, name="AnimationManager"))
 
 	if visu:
 		source = config["source"]

--- a/sofagym/envs/TrunkCup/TrunkCupToolbox.py
+++ b/sofagym/envs/TrunkCup/TrunkCupToolbox.py
@@ -14,7 +14,7 @@ import Sofa
 import Sofa.Core
 import Sofa.Simulation
 import SofaRuntime
-from splib.animation.animate import Animation
+from splib3.animation.animate import Animation
 
 SofaRuntime.importPlugin("Sofa.Component")
 
@@ -326,7 +326,7 @@ def startCmd_Trunk(rootNode, cable, displacement, duration):
             onUpdate=executeAnimation,
             params={"cable": cable,
                     "displacement": displacement},
-            duration=duration, mode="once", realTimeClock=False))
+            duration=duration, mode="once"))
 
 
 def action_to_command(action):


### PR DESCRIPTION
Some environments were still using splib not splib3. The changes I made:

- Changed splib to splib3
- Removed `realTimeClock` as it is no more used in splib3

The other issue was the observation returned from `reset()`. Some envs were returning it as a list. I modified them to return a numpy array instead for consistency and to avoid any future problems with other RL libraries or frameworks that could be used.