### PR TITLE
Fix SimpleMaze env

### DIFF
--- a/sofagym/envs/SimpleMaze/SimpleMazeEnv.py
+++ b/sofagym/envs/SimpleMaze/SimpleMazeEnv.py
@@ -13,8 +13,6 @@ import numpy as np
 
 from sofagym.AbstractEnv import AbstractEnv
 from sofagym.rpc_server import start_scene
-from sofagym.viewer import LegacyViewer
-from sofagym.envs.SimpleMaze.SimpleMazeToolbox import startCmd
 
 from gym import spaces
 
@@ -30,7 +28,7 @@ class SimpleMazeEnv(AbstractEnv):
                       "deterministic": True,
                       "source": [0, 200, 0],
                       "target": [0, 0, 0],
-                      "goalList": [301, 334, 317, 312, 301],
+                      "goalList": [301, 334, 317, 312],
                       "goal_node": 334,
                       "start_node": 269,
                       "scale_factor": 200,
@@ -62,9 +60,6 @@ class SimpleMazeEnv(AbstractEnv):
                                             dtype='float32')
 
     def step(self, action):
-        if self.viewer:
-            self.viewer.step(action)
-
         return super().step(action)
 
     def reset(self):
@@ -80,33 +75,8 @@ class SimpleMazeEnv(AbstractEnv):
 
         self.config.update({'goalPos': self.goal})
         obs = start_scene(self.config, self.nb_actions)
-        if self.viewer:
-            self.viewer.reset()
-        self.render()
 
         return np.array(obs['observation'])
-
-    def render(self, mode='rgb_array'):
-        """See the current state of the environment.
-
-        Get the OpenGL Context to render an image (snapshot) of the simulation
-        state.
-
-        Parameters:
-        ----------
-          mode: string, default = 'rgb_array'
-              Type of representation.
-
-        Returns:
-        -------
-          None.
-        """
-        if not self.viewer:
-            display_size = self.config["display_size"]  # Sim display
-            self.viewer = LegacyViewer(self, display_size, startCmd=startCmd)
-
-        # Use the viewer to display the environment.
-        self.viewer.render()
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/SimpleMaze/SimpleMazeScene.py
+++ b/sofagym/envs/SimpleMaze/SimpleMazeScene.py
@@ -8,16 +8,16 @@ __version__ = "1.0.0"
 __copyright__ = "(c) 2021, Robocath, CNRS, Inria"
 __date__ = "Mar 23 2021"
 
-import sys
+import os
 import pathlib
+import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
-import os
-from SimpleMazeToolbox import rewardShaper, goalSetter
+from maze import Maze, Sphere
+from SimpleMazeToolbox import goalSetter, rewardShaper
 from splib3.animation import AnimationManagerController
-
 
 path = os.path.dirname(os.path.abspath(__file__))
 path_mesh = path + '/mesh/'
@@ -28,7 +28,9 @@ def add_goal_node(root):
     goal.addObject('VisualStyle', displayFlags="showCollisionModels")
     goal_mo = goal.addObject('MechanicalObject', name='GoalMO', showObject=True, drawMode="1", showObjectScale=3,
                              showColor=[0, 1, 0, 1], position=[0.0, 0.0, 0.0])
-    return goal_mo
+    goal.addObject("RigidMapping", name='mapping', input=root.model.rigid_maze_mo.getLinkPath(), output=goal_mo.getLinkPath())
+    
+    return goal
 
 
 def createScene(root, config={"source": [0, 1000, 0],
@@ -55,13 +57,12 @@ def createScene(root, config={"source": [0, 1000, 0],
     if visu:
         root.addObject('VisualStyle', displayFlags="showBehaviorModels showCollisionModels hideInteractionForceFields")
 
-    if True:
-        root.addObject('DefaultPipeline')
-        root.addObject('BruteForceDetection')
-        root.addObject('RuleBasedContactManager', responseParams="mu=0.0001", name='Response', response='FrictionContactConstraint')
-        root.addObject('LocalMinDistance', alarmDistance=6, contactDistance=0.1, angleCone=0.01)
-        root.addObject('FreeMotionAnimationLoop')
-        root.addObject('GenericConstraintSolver', tolerance="1e-6", maxIterations="1000")
+    root.addObject('DefaultPipeline')
+    root.addObject('BruteForceDetection')
+    root.addObject('RuleBasedContactManager', responseParams="mu=0.0001", name='Response', response='FrictionContactConstraint')
+    root.addObject('LocalMinDistance', alarmDistance=6, contactDistance=0.1, angleCone=0.01)
+    root.addObject('FreeMotionAnimationLoop')
+    root.addObject('GenericConstraintSolver', tolerance="1e-6", maxIterations="1000")
 
     root.addObject(AnimationManagerController(root, name="AnimationManager"))
 
@@ -71,64 +72,26 @@ def createScene(root, config={"source": [0, 1000, 0],
     maze_mo = model.addObject('MechanicalObject', name='rigid_maze_mo', template='Rigid3d',
                               position=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0], showObject=True, showObjectScale=10)
     model.addObject('RestShapeSpringsForceField', angularStiffness=100, stiffness=100)
-
     model.addObject('UncoupledConstraintCorrection', compliance='1e-10  1e-10  0 0 1e-10  0 1e-10 ')
 
-    sphere = root.addChild("sphere")
-    if True:
-        sphere.addObject("EulerImplicitSolver", rayleighMass='5')
-        sphere.addObject("SparseLDLSolver", name="ldl")
-        sphere.addObject("GenericConstraintCorrection", solverName='ldl')
-    ball_mo = sphere.addObject("MechanicalObject", name="sphere_mo", template='Vec3', position=[0.0, 6.0, 2.0])
-    sphere.addObject("UniformMass", totalMass=1000)
-   
-    visu = object.addChild('Visu')
-    visu.addObject('MeshOBJLoader', name='loader', filename=ball.obj, scale3d=1)
-    visu.addObject('OglModel', src='@loader', color=[255, 0, 0, 255])
-    visu.addObject('RigidMapping')
-
-
-    object.addObject('GenerateRigidMass', name='mass', density=density, src=visu.loader.getLinkPath())
-    object.mass.init()
-    translation = list(object.mass.centerToOrigin.value)
-    object.addObject('UniformMass', vertexMass="@mass.rigidMass")
-
-    visu.loader.translation = translation
-
-    if withCollision:
-        collision = object.addChild('Collision')
-        collision.addObject('MeshOBJLoader', name='loader', filename=collisionFilename, scale3d=scale)
-        collision.addObject('MeshTopology', src='@loader')
-        collision.addObject('MechanicalObject', translation=translation)
-        collision.addObject('TriangleCollisionModel', group = collisionGroup)
-        collision.addObject('LineCollisionModel', group = collisionGroup)
-        collision.addObject('PointCollisionModel', group = collisionGroup)
-        collision.addObject('RigidMapping')
-
-    maze = model.addChild("maze")
-    maze.addObject("MeshSTLLoader", name="loader", filename=path_mesh+"maze_4_coarse.stl",
-                   translation=[-50.0, 0.0, 50.0], rotation=[-90.0, 0.0, 0.0])
-    maze.addObject("Mesh", src='@loader')
-    maze.addObject("MechanicalObject", name='maze_mesh_mo')
-    if True:
-        maze.addObject("Triangle", group=1)
-        maze.addObject("Line", group=1)
-        maze.addObject("Point", group=1)
-        maze.addObject("RigidMapping")
+    maze = model.addChild(Maze())
+    maze.addObject("RigidMapping")
+    
+    sphere = root.addChild(Sphere())
+    ball_mo = sphere.sphere_mo
 
     path_node = maze.addChild("Path")
     p_mesh = path_node.addObject('MeshObjLoader', filename=path_mesh+"path.obj", flipNormals=True, triangulate=True,
                                  name='meshLoader', translation=[-50.0, 0.0, 50.0])
-    p_mo = path_node.addObject("MechanicalObject", template="Rigid3d", name="dofs", position="@meshLoader.position",
+    p_mo = path_node.addObject("MechanicalObject", template="Vec3d", name="dofs", position="@meshLoader.position",
                                showObject=True, showObjectScale=1.0)
-    if True:
-        path_node.addObject("RigidMapping", input=maze_mo.getLinkPath(), output=p_mo.getLinkPath())
+    path_node.addObject("RigidMapping", input=maze_mo.getLinkPath(), output=p_mo.getLinkPath())
 
-    goal_mo = add_goal_node(root)
+    goal = add_goal_node(root)
 
     root.addObject(rewardShaper(name="Reward", rootNode=root, goal_node=config['goalList'][config['goal_node']],
                                 path_mesh=p_mesh, path_mo=p_mo, ball_mo=ball_mo))
-    root.addObject(goalSetter(name="GoalSetter", rootNode=root, goalMO=goal_mo, goalPos=config['goalPos']))
+    root.addObject(goalSetter(name="GoalSetter", rootNode=root, goal=goal, goalPos=config['goalPos']))
 
     if visu:
         source = config["source"]

--- a/sofagym/envs/SimpleMaze/SimpleMazeScene.py
+++ b/sofagym/envs/SimpleMaze/SimpleMazeScene.py
@@ -15,7 +15,8 @@ import sys
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
-from maze import Maze, Sphere
+from Maze import Maze
+from Sphere import Sphere
 from SimpleMazeToolbox import goalSetter, rewardShaper
 from splib3.animation import AnimationManagerController
 

--- a/sofagym/envs/SimpleMaze/SimpleMazeToolbox.py
+++ b/sofagym/envs/SimpleMaze/SimpleMazeToolbox.py
@@ -226,9 +226,9 @@ class goalSetter(Sofa.Core.Controller):
         self.rootNode = None
         if kwargs["rootNode"]:
             self.rootNode = kwargs["rootNode"]
-        self.goalMO = None
-        if kwargs["goalMO"]:
-            self.goalMO = kwargs["goalMO"]
+        self.goal = None
+        if kwargs["goal"]:
+            self.goal = kwargs["goal"]
         self.goalPos = None
         if kwargs["goalPos"]:
             self.goalPos = kwargs["goalPos"]
@@ -247,8 +247,10 @@ class goalSetter(Sofa.Core.Controller):
             None.
 
         """
-        new_position = self.rootNode.model.maze.Path.dofs.position.value[self.goalPos][:3]
-        with self.goalMO.position.writeable() as position:
+        new_position = self.rootNode.model.Maze.Path.dofs.position.value[self.goalPos][:3]
+        with self.goal.GoalMO.position.writeable() as position:
+            position[0] = new_position
+        with self.goal.mapping.initialPoints.writeable() as position:
             position[0] = new_position
 
     def set_mo_pos(self, goal):
@@ -292,7 +294,7 @@ def getState(root):
 
     goal_pos = _getGoalPos(root).tolist()
     maze_rigid_pos = root.model.rigid_maze_mo.position.value[0]
-    sphere_pos = root.sphere.sphere_mo.position.value[0]
+    sphere_pos = root.Sphere.sphere_mo.position.value[0]
 
     state = [round(float(k), cs) for k in sphere_pos] + [round(float(k), cs) for k in maze_rigid_pos] + goal_pos
 
@@ -313,7 +315,7 @@ def getReward(root):
 
     """
 
-    spheres = root.sphere.sphere_mo.position.value[:3]
+    spheres = root.Sphere.sphere_mo.position.value[:3]
     goal = root.Goal.GoalMO.position.value[:3]
     if np.linalg.norm(spheres-goal) <= 10:
         print("Terminal State")
@@ -448,8 +450,8 @@ def getPos(root):
 
     root.GoalSetter.update()
 
-    maze = root.model.maze.maze_mesh_mo.position.value.tolist()
-    spheres = root.sphere.sphere_mo.position.value.tolist()
+    maze = root.model.Maze.maze_mesh_mo.position.value.tolist()
+    spheres = root.Sphere.sphere_mo.position.value.tolist()
 
     rigid = root.model.rigid_maze_mo.position.value.tolist()
 
@@ -479,8 +481,8 @@ def setPos(root, pos):
     """
     [maze, spheres, rigid, goal] = pos
 
-    root.model.maze.maze_mesh_mo.position.value = np.array(maze)
-    root.sphere.sphere_mo.position.value = np.array(spheres)
+    root.model.Maze.maze_mesh_mo.position.value = np.array(maze)
+    root.Sphere.sphere_mo.position.value = np.array(spheres)
 
     root.model.rigid_maze_mo.position.value = np.array(rigid)
     root.Goal.GoalMO.position.value = np.array(goal)

--- a/sofagym/envs/SimpleMaze/Sphere.py
+++ b/sofagym/envs/SimpleMaze/Sphere.py
@@ -1,40 +1,6 @@
-import os
-import pathlib
-import sys
-
 import Sofa
 import Sofa.Core
 from stlib3.scene.contactheader import ContactHeader
-
-
-sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
-sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
-
-path = os.path.dirname(os.path.abspath(__file__))
-path_mesh = path + '/mesh/'
-
-
-class Maze(Sofa.Prefab):
-    prefabParameters = [
-        {'name': 'translation', 'type': 'Vec3d', 'help': '', 'default': [-50.0, 0.0, 50.0]},
-        {'name': 'rotation', 'type': 'Vec3d', 'help': '', 'default': [-90.0, 0.0, 0.0]}
-    ]
-
-    prefabData = [
-        {'name': 'index', 'type': 'int', 'help': 'index of rigid to attach to', 'default': 0},
-    ]
-
-    def __init__(self, *args, **kwargs):
-        Sofa.Prefab.__init__(self, *args, **kwargs)
-
-    def init(self):
-        self.addObject("MeshSTLLoader", name="loader", filename=path_mesh+"maze_4_coarse.stl",
-                       translation=self.translation.value, rotation=self.rotation.value)
-        self.addObject("MeshTopology", src='@loader')
-        self.addObject("MechanicalObject", name='maze_mesh_mo')
-        self.addObject("TriangleCollisionModel")
-        self.addObject("LineCollisionModel")
-        self.addObject("PointCollisionModel")
 
 
 class Sphere(Sofa.Prefab):
@@ -80,17 +46,6 @@ def createScene(rootNode):
     ContactHeader(rootNode, alarmDistance=15, contactDistance=0.5, frictionCoef=0)
     rootNode.addObject('VisualStyle', displayFlags=['showCollisionModels', 'showBehavior'])
     rootNode.addObject('DefaultVisualManagerLoop')
-
-    effector = rootNode.addChild('Effector')
-    effector.addObject('EulerImplicitSolver', firstOrder=True)
-    effector.addObject('CGLinearSolver', iterations=100, threshold=1e-5, tolerance=1e-5)
-    effector.addObject('MechanicalObject', template='Rigid3', name='goalMO', position=[0, 40, 0, 0, 0, 0, 1],
-                       showObject=True, showObjectScale=10)
-    effector.addObject('RestShapeSpringsForceField', points=0, angularStiffness=1e5, stiffness=1e5)
-    effector.addObject('UncoupledConstraintCorrection', compliance='1e-10  1e-10  0 0 1e-10  0 1e-10 ')
-
-    maze = effector.addChild(Maze())
-    maze.addObject("RigidMapping", index=0)
 
     rootNode.addChild(Sphere(withSolver=True))
 

--- a/sofagym/envs/SimpleMaze/maze.py
+++ b/sofagym/envs/SimpleMaze/maze.py
@@ -1,0 +1,97 @@
+import os
+import pathlib
+import sys
+
+import Sofa
+import Sofa.Core
+from stlib3.scene.contactheader import ContactHeader
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
+sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
+
+path = os.path.dirname(os.path.abspath(__file__))
+path_mesh = path + '/mesh/'
+
+
+class Maze(Sofa.Prefab):
+    prefabParameters = [
+        {'name': 'translation', 'type': 'Vec3d', 'help': '', 'default': [-50.0, 0.0, 50.0]},
+        {'name': 'rotation', 'type': 'Vec3d', 'help': '', 'default': [-90.0, 0.0, 0.0]}
+    ]
+
+    prefabData = [
+        {'name': 'index', 'type': 'int', 'help': 'index of rigid to attach to', 'default': 0},
+    ]
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Prefab.__init__(self, *args, **kwargs)
+
+    def init(self):
+        self.addObject("MeshSTLLoader", name="loader", filename=path_mesh+"maze_4_coarse.stl",
+                       translation=self.translation.value, rotation=self.rotation.value)
+        self.addObject("MeshTopology", src='@loader')
+        self.addObject("MechanicalObject", name='maze_mesh_mo')
+        self.addObject("TriangleCollisionModel")
+        self.addObject("LineCollisionModel")
+        self.addObject("PointCollisionModel")
+
+
+class Sphere(Sofa.Prefab):
+    prefabParameters = [
+        {'name': 'position', 'type': 'Vec3d', 'help': '', 'default': [0.0, 6.0, 2.0]},
+        {'name': 'withSolver', 'type': 'bool', 'help': '', 'default': True}
+    ]
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Prefab.__init__(self, *args, **kwargs)
+
+    def init(self):
+        if self.withSolver.value:
+            self.addObject('EulerImplicitSolver')
+            self.addObject('SparseLDLSolver', template="CompressedRowSparseMatrixd")
+            self.addObject('GenericConstraintCorrection')
+        self.addObject("MechanicalObject", position=self.position.value, name="sphere_mo")
+        self.addObject("UniformMass", totalMass=1e-4)
+        self.addObject('SphereCollisionModel', radius=2)
+
+
+def createScene(rootNode):
+    rootNode.gravity = [0., -9810., 0.]
+    rootNode.dt = 0.01
+
+    pluginList = ["Sofa.Component.AnimationLoop",
+                  "Sofa.Component.Collision.Detection.Algorithm",
+                  "Sofa.Component.Collision.Detection.Intersection",
+                  "Sofa.Component.Collision.Geometry",
+                  "Sofa.Component.Collision.Response.Contact",
+                  "Sofa.Component.Constraint.Lagrangian.Correction",
+                  "Sofa.Component.Constraint.Lagrangian.Solver",
+                  "Sofa.Component.IO.Mesh", "Sofa.Component.LinearSolver.Direct",
+                  "Sofa.Component.LinearSolver.Iterative", "Sofa.Component.Mass",
+                  "Sofa.Component.ODESolver.Backward",
+                  "Sofa.Component.SolidMechanics.Spring",
+                  "Sofa.Component.StateContainer",
+                  "Sofa.Component.Topology.Container.Constant",
+                  "Sofa.Component.Visual"]
+
+    rootNode.addObject('RequiredPlugin', pluginName=pluginList)
+
+    ContactHeader(rootNode, alarmDistance=15, contactDistance=0.5, frictionCoef=0)
+    rootNode.addObject('VisualStyle', displayFlags=['showCollisionModels', 'showBehavior'])
+    rootNode.addObject('DefaultVisualManagerLoop')
+
+    effector = rootNode.addChild('Effector')
+    effector.addObject('EulerImplicitSolver', firstOrder=True)
+    effector.addObject('CGLinearSolver', iterations=100, threshold=1e-5, tolerance=1e-5)
+    effector.addObject('MechanicalObject', template='Rigid3', name='goalMO', position=[0, 40, 0, 0, 0, 0, 1],
+                       showObject=True, showObjectScale=10)
+    effector.addObject('RestShapeSpringsForceField', points=0, angularStiffness=1e5, stiffness=1e5)
+    effector.addObject('UncoupledConstraintCorrection', compliance='1e-10  1e-10  0 0 1e-10  0 1e-10 ')
+
+    maze = effector.addChild(Maze())
+    maze.addObject("RigidMapping", index=0)
+
+    rootNode.addChild(Sphere(withSolver=True))
+
+    return


### PR DESCRIPTION
Fixed the SimpleMaze environment:
- Changed the viewer used for rendering to the `Viewer` class instead of `LegacyViewer`.
- Added and used the `Maze` and `Sphere` classes based on Sofa prefab.
- Added mapping between the goal and the maze to attach the goal to the maze.