### PR TITLE
Remove rng re-init during episode reset

### DIFF
--- a/sofagym/AbstractEnv.py
+++ b/sofagym/AbstractEnv.py
@@ -375,8 +375,6 @@ class AbstractEnv(gym.Env):
         self.clean()
         self.viewer = None
 
-        self.seed(self.config['seed'])
-
         splib3.animation.animate.manager = None
         if not self.goalList:
             self.goalList = self.config["goalList"]


### PR DESCRIPTION
Calling the `seed` method with the same seed value at the start of each episode causes the rng to be reinitialized to the same values each time, making the goal chosen the same every time and not randomized.

Removing this method call at each reset fixes the issue, as the rng is not reinitialized and a new goal is chosen at the start of the new episode.