### PR TITLE
Fix gripper env observation return

### DIFF
--- a/sofagym/envs/Gripper/GripperEnv.py
+++ b/sofagym/envs/Gripper/GripperEnv.py
@@ -76,9 +76,8 @@ class GripperEnv(AbstractEnv):
 
         self.config.update({'goalPos': self.goal})
         obs = start_scene(self.config, self.nb_actions)
-        info = {}
 
-        return (np.array(obs['observation']), info)
+        return (np.array(obs['observation']))
 
     def get_available_actions(self):
         """Gives the actions available in the environment.
@@ -92,4 +91,3 @@ class GripperEnv(AbstractEnv):
             list of the action available in the environment.
         """
         return list(range(int(self.nb_actions)))
-


### PR DESCRIPTION
Fix issue from discussion https://github.com/sofa-framework/sofa/discussions/3941#discussioncomment-6332567
The observation returned from the reset method was a tuple of both the obs array and and empty info dict. Since the info dict is not used to save any data in this case, it is removed.