### PR TITLE
Maze fix state

### DIFF
--- a/sofagym/envs/Maze/MazeEnv.py
+++ b/sofagym/envs/Maze/MazeEnv.py
@@ -55,7 +55,7 @@ class MazeEnv(AbstractEnv):
         self.action_space = spaces.Discrete(nb_actions)
         self.nb_actions = str(nb_actions)
 
-        dim_state = 13
+        dim_state = 9
         low_coordinates = np.array([-1]*dim_state)
         high_coordinates = np.array([1]*dim_state)
         self.observation_space = spaces.Box(low_coordinates, high_coordinates, dtype='float32')

--- a/sofagym/envs/Maze/MazeScene.py
+++ b/sofagym/envs/Maze/MazeScene.py
@@ -142,7 +142,7 @@ def createScene(rootNode, config={"source": [0, 300, 0],
 
     goal = add_goal_node(rootNode)
 
-    rootNode.addObject(rewardShaper(name="Reward", rootNode=rootNode, goal_node=config['goalList'][config['goal_node']],
+    rootNode.addObject(rewardShaper(name="Reward", rootNode=rootNode, goal_node=config['goalPos'],
                                     path_mesh=p_mesh, path_mo=p_mo, ball_mo=ball_mo))
     rootNode.addObject(goalSetter(name="GoalSetter", rootNode=rootNode, goal=goal, goalPos=config['goalPos']))
     

--- a/sofagym/envs/Maze/MazeToolbox.py
+++ b/sofagym/envs/Maze/MazeToolbox.py
@@ -272,6 +272,8 @@ def getReward(rootNode):
         done, reward
 
     """
+    goal_radius = 5
+    ball_fall_threshold = -100
     done = False
 
     goal = rootNode.Goal.GoalMO.position.value[0]
@@ -280,7 +282,7 @@ def getReward(rootNode):
 
     reward, cost = rootNode.Reward.getReward()
 
-    if dist < 5 or ball_pos[1] < -100:
+    if dist < goal_radius or ball_pos[1] < ball_fall_threshold:
         done = True
 
     return done, reward

--- a/sofagym/envs/Maze/MazeToolbox.py
+++ b/sofagym/envs/Maze/MazeToolbox.py
@@ -205,7 +205,6 @@ class goalSetter(Sofa.Core.Controller):
         new_position = self.rootNode.Modelling.Tripod.RigidifiedStructure.FreeCenter.Maze.Path.dofs.position.value[self.goalPos][:3]
         with self.goal.GoalMO.position.writeable() as position:
             position[0] = new_position
-            position[0][1] = 5
         with self.goal.mapping.initialPoints.writeable() as position:
             position[0] = new_position
             position[0][1] = 5
@@ -273,10 +272,18 @@ def getReward(rootNode):
         done, reward
 
     """
+    done = False
+
+    goal = rootNode.Goal.GoalMO.position.value[0]
+    ball_pos = rootNode.Simulation.Sphere.sphere_mo.position.value[0]
+    dist = np.linalg.norm(ball_pos - goal)
 
     reward, cost = rootNode.Reward.getReward()
 
-    return False, reward
+    if dist < 5 or ball_pos[1] < -100:
+        done = True
+
+    return done, reward
 
 
 def startCmd(root, action, duration):
@@ -396,9 +403,6 @@ def getPos(root):
         _: list
             The position(s) of the object(s) of the scene.
     """
-
-    root.GoalSetter.update()
-
     maze = root.Modelling.Tripod.RigidifiedStructure.FreeCenter.Maze.maze_mesh_mo.position.value.tolist()
     spheres = root.Simulation.Sphere.sphere_mo.position.value.tolist()
 


### PR DESCRIPTION
- There was a mismatch between the observation space defined in the environment (13) and the actual state dimension returned (9). It is now fixed to be 9 representing the 3d position of the ball, the maze, and the goal.
- The termination condition of the episode was set to be always 'False'. It will now change to 'True' when the ball either falls from the maze or successfully reaches the goal point.
- Removed an unnecessary update of the goal when getting the new positions of the scene components at each step, since the goal doesn't change between the steps, it only changes after each episode.