### PR TITLE
Fix CTR and Diamond envs

### DIFF
--- a/sofagym/envs/CTR/CTREnv.py
+++ b/sofagym/envs/CTR/CTREnv.py
@@ -58,7 +58,7 @@ class ConcentricTubeRobotEnv(AbstractEnv):
         self.action_space = spaces.Discrete(nb_actions)
         self.nb_actions = str(nb_actions)
 
-        dim_state = 1
+        dim_state = 12
         low_coordinates = np.array([-1]*dim_state)
         high_coordinates = np.array([1]*dim_state)
         self.observation_space = spaces.Box(low_coordinates, high_coordinates,
@@ -88,7 +88,6 @@ class ConcentricTubeRobotEnv(AbstractEnv):
         self.goal = [0.0, y, abs(y) + 30 * np.random.random()]
 
         self.config.update({'goalPos': self.goal})
-        print(self.config)
         obs = start_scene(self.config, self.nb_actions)
         if self.viewer:
             self.viewer.reset()

--- a/sofagym/envs/CTR/CTREnv.py
+++ b/sofagym/envs/CTR/CTREnv.py
@@ -86,24 +86,16 @@ class ConcentricTubeRobotEnv(AbstractEnv):
         y = -20 + 50 * np.random.random()
 
         self.goal = [0.0, y, abs(y) + 30 * np.random.random()]
-        # self.goal = [0.0, 50, 65]
-        # self.goal = [0.0, 20, 70]
-        # self.goal = [0.0, 30, 35]
-        # self.goal = [0.0, -7, 45]
 
         self.config.update({'goalPos': self.goal})
         print(self.config)
         obs = start_scene(self.config, self.nb_actions)
         if self.viewer:
             self.viewer.reset()
-        self.render()
 
         self.step(0)
-        self.render()
         self.step(4)
-        self.render()
         self.step(8)
-        self.render()
 
         return np.array(obs['observation'])
 
@@ -141,5 +133,3 @@ class ConcentricTubeRobotEnv(AbstractEnv):
             list of the action available in the environment.
         """
         return list(range(int(self.nb_actions)))
-
-

--- a/sofagym/envs/CTR/CTRToolbox.py
+++ b/sofagym/envs/CTR/CTRToolbox.py
@@ -353,8 +353,8 @@ def action_to_command(action, scale):
         cmd_rotation = 0.0
     elif action == 5:
         controlled_instrument = 1
-        cmd_translation = -0.7 * scale / 2.5
-        cmd_rotation = 0.0
+        cmd_translation = 0.0
+        cmd_rotation = 1/15 * scale / 2.5
     elif action == 6:
         controlled_instrument = 1
         cmd_translation = 0.0
@@ -370,8 +370,8 @@ def action_to_command(action, scale):
         cmd_rotation = 0.0
     elif action == 9:
         controlled_instrument = 2
-        cmd_translation = -0.7 * scale / 3.0
-        cmd_rotation = 0.0
+        cmd_translation = 0.0
+        cmd_rotation = 1/15 * scale / 3.0
     elif action == 10:
         controlled_instrument = 2
         cmd_translation = 0.0
@@ -382,7 +382,7 @@ def action_to_command(action, scale):
         cmd_rotation = 0.0
 
     else:
-        raise NotImplementedError("Action is not in range 0 - 7")
+        raise NotImplementedError("Action is not in range 0 - 11")
 
     return controlled_instrument, cmd_translation, cmd_rotation
 

--- a/sofagym/envs/CTR/CTRToolbox.py
+++ b/sofagym/envs/CTR/CTRToolbox.py
@@ -186,7 +186,7 @@ def _getGoalPos(root):
     -------
         The position of the goal.
     """
-    return root.goal.goalMO.position[0]
+    return root.Goal.GoalMO.position[0]
 
 
 def getState(root):
@@ -202,7 +202,18 @@ def getState(root):
         State: list of float
             The state of the environment/agent.
     """
-    state = [0]
+    xtips = []
+    rotations = []
+
+    for instrument in range(3):
+        xtips.append(root.InstrumentCombined.m_ircontroller.xtip.value[instrument].tolist())
+        rotations.append(root.InstrumentCombined.m_ircontroller.rotationInstrument.value[instrument].tolist())
+
+    tip = root.InstrumentCombined.DOFs.position[-1][:3].tolist()
+
+    goal_pos = _getGoalPos(root).tolist()
+
+    state = xtips + rotations + tip + goal_pos
 
     return state
 

--- a/sofagym/envs/CTR/CTRToolbox.py
+++ b/sofagym/envs/CTR/CTRToolbox.py
@@ -202,7 +202,7 @@ def getState(root):
         State: list of float
             The state of the environment/agent.
     """
-    state = 0
+    state = [0]
 
     return state
 

--- a/sofagym/envs/Diamond/DiamondEnv.py
+++ b/sofagym/envs/Diamond/DiamondEnv.py
@@ -83,10 +83,11 @@ class DiamondRobotEnv(AbstractEnv):
         obs = start_scene(self.config, self.nb_actions)
         if self.viewer:
             self.viewer.reset()
-        self.render()
+        #self.render()
 
         return np.array(obs['observation'])
 
+    
     def render(self, mode='rgb_array'):
         """See the current state of the environment.
 
@@ -108,6 +109,7 @@ class DiamondRobotEnv(AbstractEnv):
 
         # Use the viewer to display the environment.
         self.viewer.render()
+    
 
     def get_available_actions(self):
         """Gives the actions available in the environment.

--- a/sofagym/envs/Diamond/DiamondEnv.py
+++ b/sofagym/envs/Diamond/DiamondEnv.py
@@ -54,9 +54,9 @@ class DiamondRobotEnv(AbstractEnv):
         self.action_space = spaces.Discrete(nb_actions)
         self.nb_actions = str(nb_actions)
 
-        dim_state = 5
-        low_coordinates = np.array([-1]*dim_state)
-        high_coordinates = np.array([1]*dim_state)
+        dim_state = (6, 3)
+        low_coordinates = np.ones(shape=dim_state)*-1
+        high_coordinates = np.ones(shape=dim_state)
         self.observation_space = spaces.Box(low_coordinates, high_coordinates,
                                             dtype='float32')
 

--- a/sofagym/envs/Diamond/DiamondEnv.py
+++ b/sofagym/envs/Diamond/DiamondEnv.py
@@ -83,7 +83,6 @@ class DiamondRobotEnv(AbstractEnv):
         obs = start_scene(self.config, self.nb_actions)
         if self.viewer:
             self.viewer.reset()
-        #self.render()
 
         return np.array(obs['observation'])
 


### PR DESCRIPTION
- Diamond Env:
  - Fixed observation space shape to match the returned state.
  - Removed rendering call during episode reset.
- CTR Env:
  - Changed the env observation to include the state of the robot (the instruments' tips x positions and rotations) and the goal.
  - Fixed the actions. There was a duplicate action for each instrument for the negative translation but there was not action for the positive rotation.
  - Removed rendering call during episode reset.