### PR TITLE
[Core] Add no server architecture implementation to the environments

### DIFF
--- a/sofagym/AbstractEnv.py
+++ b/sofagym/AbstractEnv.py
@@ -19,7 +19,6 @@ import os
 
 import splib3
 
-from sofagym.rpc_server import start_server, add_new_step, get_result, clean_registry, close_scene
 from sofagym.viewer import Viewer
 
 import importlib
@@ -366,45 +365,7 @@ class AbstractEnv(gym.Env):
         info = {} #(not use here)
 
         return obs, reward, done, info
-
-    def async_step(self, action):
-        """Executes one action in the environment.
-
-        Apply action and execute scale_factor simulation steps of 0.01 s.
-        Like step but useful if you want to parallelise (blocking "get").
-        Otherwise use step.
-
-        Parameters:
-        ----------
-            action: int
-                Action applied in the environment.
-
-        Returns:
-        -------
-            LateResult:
-                Class which allows to store the id of the client who performs
-                the calculation and to return later the usual information
-                (observation, reward, done) thanks to a get method.
-
-        """
-        assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
-
-        result_id = add_new_step(self.past_actions, action)
-        self.past_actions.append(action)
-
-        class LateResult:
-            def __init__(self, result_id):
-                self.result_id = result_id
-
-            def get(self, timeout=None):
-                results = get_result(self.result_id, timeout=timeout)
-                obs = results["observation"]
-                reward = results["reward"]
-                done = results["done"]
-                return obs, reward, done, {}
-
-        return LateResult(copy.copy(result_id))
-
+    
     def reset(self):
         """Reset simulation.
 
@@ -595,114 +556,3 @@ class AbstractEnv(gym.Env):
             pos.append(self._getPos(self.root))
 
         return pos
-
-
-
-
-class ServerEnv(AbstractEnv):
-    def __init__(self, default_config, config=None, render_mode: Optional[str]=None, root=None):
-        super().__init__(default_config, config, root=root)
-        
-        # Start the server which distributes the calculations to its clients
-        start_server(self.config)
-
-    def step(self, action):
-        """Executes one action in the environment.
-
-        Apply action and execute scale_factor simulation steps of 0.01 s.
-
-        Parameters:
-        ----------
-            action: int
-                Action applied in the environment.
-
-        Returns:
-        -------
-            obs(ObsType):
-                The new state of the agent.
-            reward(float):
-                The reward obtain after applying the action in the current state.
-            done(bool):
-                Whether the agent reaches the terminal state
-            info(dict): 
-                additional information (not used here)
-        """
-        # assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
-
-        action = self._formataction(action)
-
-        # Pass the actions to the server to launch the simulation.
-        result_id = add_new_step(self.past_actions, action)
-        self.past_actions.append(action)
-
-        # Request results from the server.
-        # print("[INFO]   >>> Result id:", result_id)
-        results = get_result(result_id, timeout=self.timeout)
-
-        obs = np.array(results["observation"])  # to work with baseline
-        reward = results["reward"]
-        done = results["done"]
-
-        # Avoid long explorations by using a timer.
-        self.timer += 1
-        if self.timer >= self.config["timer_limit"]:
-            # reward = -150
-            truncated = True
-        info={}#(not use here)
-
-        if self.config["planning"]:
-            self.clean()
-        return obs, reward, done, info
-    
-    def reset(self):
-        """Reset simulation.
-
-        Parameters:
-        ----------
-            None.
-
-        Returns:
-        -------
-            obs, info
-        """
-        self.clean()
-        self.viewer = None
-
-        splib3.animation.animate.manager = None
-
-        self.timer = 0
-        self.past_actions = []
-        
-        return
-    
-    def clean(self):
-        """Function to clean the registery .
-
-        Close clients who are processing unused sequences of actions (for
-        planning)
-
-        Parameters:
-        ----------
-            None.
-
-        Returns:
-        -------
-            None.
-        """
-        clean_registry(self.past_actions)
-
-    def close(self):
-        """Terminate simulation.
-
-        Close the viewer and the scene.
-
-        Parametres:
-        ----------
-            None.
-
-        Returns:
-        -------
-            None.
-        """
-        super().close()
-        close_scene()

--- a/sofagym/AbstractEnv.py
+++ b/sofagym/AbstractEnv.py
@@ -19,6 +19,7 @@ import os
 
 import splib3
 
+from sofagym.rpc_server import start_server, add_new_step, get_result, clean_registry, close_scene
 from sofagym.viewer import Viewer
 
 import importlib
@@ -115,7 +116,7 @@ class AbstractEnv(gym.Env):
 
 
     """
-    def __init__(self, config=None, render_mode: Optional[str]=None, root=None):
+    def __init__(self, default_config, config=None, render_mode: Optional[str]=None, root=None):
         """
         Classic initialization of a class in python.
 
@@ -130,7 +131,7 @@ class AbstractEnv(gym.Env):
 
         """
         # Define a DEFAULT_CONFIG in sub-class.
-        self.config = copy.deepcopy(self.DEFAULT_CONFIG)
+        self.config = copy.deepcopy(default_config)
         self.config["dt"] = self.config.get('dt', 0.01)
         if config is not None:
             self.config.update(config)
@@ -556,3 +557,122 @@ class AbstractEnv(gym.Env):
             pos.append(self._getPos(self.root))
 
         return pos
+
+
+
+
+class ServerEnv(AbstractEnv):
+    def __init__(self, default_config, config=None, render_mode: Optional[str]=None, root=None):
+        super().__init__(default_config, config, root=root)
+        
+        # Start the server which distributes the calculations to its clients
+        start_server(self.config)
+
+    def step(self, action):
+        """Executes one action in the environment.
+
+        Apply action and execute scale_factor simulation steps of 0.01 s.
+
+        Parameters:
+        ----------
+            action: int
+                Action applied in the environment.
+
+        Returns:
+        -------
+            obs(ObsType):
+                The new state of the agent.
+            reward(float):
+                The reward obtain after applying the action in the current state.
+            done(bool):
+                Whether the agent reaches the terminal state
+            info(dict): 
+                additional information (not used here)
+        """
+
+        # assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
+
+        action = self._formataction(action)
+
+        # Pass the actions to the server to launch the simulation.
+        result_id = add_new_step(self.past_actions, action)
+        self.past_actions.append(action)
+
+        # Request results from the server.
+        # print("[INFO]   >>> Result id:", result_id)
+        results = get_result(result_id, timeout=self.timeout)
+
+        obs = np.array(results["observation"])  # to work with baseline
+        reward = results["reward"]
+        done = results["done"]
+
+        # Avoid long explorations by using a timer.
+        self.timer += 1
+        if self.timer >= self.config["timer_limit"]:
+            # reward = -150
+            truncated = True
+        info={}#(not use here)
+
+        if self.config["planning"]:
+            self.clean()
+        return obs, reward, done, info
+    
+    def reset(self):
+        """Reset simulation.
+
+        Parameters:
+        ----------
+            None.
+
+        Returns:
+        -------
+            obs, info
+        """
+        self.clean()
+        self.viewer = None
+
+        splib3.animation.animate.manager = None
+        if not self.goalList:
+            self.goalList = self.config["goalList"]
+
+        # Set a new random goal from the list
+        id_goal = self.np_random.choice(range(len(self.goalList)))
+        self.config.update({'goal_node': id_goal})
+        self.goal = self.goalList[id_goal]
+
+        self.timer = 0
+        self.past_actions = []
+        
+        return
+    
+    def clean(self):
+        """Function to clean the registery .
+
+        Close clients who are processing unused sequences of actions (for
+        planning)
+
+        Parameters:
+        ----------
+            None.
+
+        Returns:
+        -------
+            None.
+        """
+        clean_registry(self.past_actions)
+
+    def close(self):
+        """Terminate simulation.
+
+        Close the viewer and the scene.
+
+        Parametres:
+        ----------
+            None.
+
+        Returns:
+        -------
+            None.
+        """
+        super().close()
+        close_scene()

--- a/sofagym/AbstractEnv.py
+++ b/sofagym/AbstractEnv.py
@@ -499,12 +499,6 @@ class AbstractEnv(gym.Env):
             self.config.update({'render': render})
             print(">>   ... Done.")
 
-        # Init Reward and GoalSetter
-        if self.config["goal"]:
-            self.root.GoalSetter.update(self.goal)
-        
-        self.root.Reward.update(0)
-
         if self.config["randomize_states"]:
             self.root.StateInitializer.init_state(self.config["init_states"])
 
@@ -514,11 +508,11 @@ class AbstractEnv(gym.Env):
                 Sofa.Simulation.animate(self.root, self.config["dt"])
             print(">>   ... Done.")
             
-            # Update Reward and GoalSetter
-            if self.config["goal"]:
-                self.root.GoalSetter.update(self.goal)
-            
-            self.root.Reward.update(self.goal)
+        # Update Reward and GoalSetter
+        if self.config["goal"]:
+            self.root.GoalSetter.update(self.goal)
+        
+        self.root.Reward.update(self.goal)
 
     def step_simulation(self, action):
         """Realise one step in the simulation.

--- a/sofagym/AbstractEnv.py
+++ b/sofagym/AbstractEnv.py
@@ -149,16 +149,9 @@ class AbstractEnv(gym.Env):
             print("sofagym.envs."+self.scene+"." + self.scene + "Scene")
             raise NotImplementedError("Importing your SOFA Scene Failed") from exc
 
-        if isinstance(root, type(None)):
-            self.root = self.init_simulation()
-        else:
-            self.root = root
-
         self.viewer = None
         self.render_mode = render_mode
 
-        self.goalList = None
-        self.goal = None
         self.past_actions = []
 
         self.pos = []
@@ -174,6 +167,23 @@ class AbstractEnv(gym.Env):
         self.timeout = self.config["timeout"]
 
         self.init_save_paths()
+
+        self.goal = None
+        if self.config["goal"]:
+            self.goalList = self.config["goalList"]
+            self.init_goal()
+
+        if isinstance(root, type(None)):
+            self.root = self.init_simulation()
+        else:
+            self.root = root
+
+    def init_goal(self):
+        # Set a new random goal from the list
+        id_goal = self.np_random.choice(range(len(self.goalList)))
+        self.config.update({'goal_node': id_goal})
+        self.goal = self.goalList[id_goal]
+        self.config.update({'goalPos': self.goal})
 
     def init_save_paths(self):
         """Create directories to save results and images.
@@ -298,7 +308,6 @@ class AbstractEnv(gym.Env):
     
             
         """
-
         # assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
 
         action = self._formataction(action)
@@ -374,13 +383,9 @@ class AbstractEnv(gym.Env):
         self.viewer = None
 
         splib3.animation.animate.manager = None
-        if not self.goalList:
-            self.goalList = self.config["goalList"]
 
-        # Set a new random goal from the list
-        id_goal = self.np_random.choice(range(len(self.goalList)))
-        self.config.update({'goal_node': id_goal})
-        self.goal = self.goalList[id_goal]
+        if self.config["goal"]:
+            self.init_goal()
 
         self.timer = 0
         self.past_actions = []
@@ -492,8 +497,10 @@ class AbstractEnv(gym.Env):
             print(">>   ... Done.")
 
         # Init Reward and GoalSetter
-        root.GoalSetter.update(self.config["goalList"])
-        root.Reward.update(self.config["goalList"])
+        if self.config["goal"]:
+            root.GoalSetter.update(self.goal)
+        
+        root.Reward.update(0)
 
         try:
             root.StateInitializer.init_state(self.config["init_states"])
@@ -505,9 +512,12 @@ class AbstractEnv(gym.Env):
             for _ in range(self.config["time_before_start"]):
                 Sofa.Simulation.animate(root, self.config["dt"])
             print(">>   ... Done.")
+            
             # Update Reward and GoalSetter
-            root.GoalSetter.update(self.config["goalList"])
-            root.Reward.update(self.config["goalList"])
+            if self.config["goal"]:
+                root.GoalSetter.update(self.goal)
+            
+            root.Reward.update(self.goal)
 
         return root
 
@@ -535,11 +545,12 @@ class AbstractEnv(gym.Env):
                 The positions of object(s) in the scene.
 
         """
-        goal = self.config['goalPos']
+        if self.config["goal"]:
+            goal = self.config['goalPos']
+            self.root.GoalSetter.set_mo_pos(goal)
+        
         render = self.config['render']
         surface_size = self.config['display_size']
-
-        self.root.GoalSetter.set_mo_pos(goal)
 
         # Create the command from action
         self._startCmd(self.root, action, self.config["dt"]*(self.config["scale_factor"]-1))
@@ -589,7 +600,6 @@ class ServerEnv(AbstractEnv):
             info(dict): 
                 additional information (not used here)
         """
-
         # assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
 
         action = self._formataction(action)
@@ -632,13 +642,9 @@ class ServerEnv(AbstractEnv):
         self.viewer = None
 
         splib3.animation.animate.manager = None
-        if not self.goalList:
-            self.goalList = self.config["goalList"]
-
-        # Set a new random goal from the list
-        id_goal = self.np_random.choice(range(len(self.goalList)))
-        self.config.update({'goal_node': id_goal})
-        self.goal = self.goalList[id_goal]
+        
+        if self.config["goal"]:
+            self.init_goal()
 
         self.timer = 0
         self.past_actions = []

--- a/sofagym/ServerEnv.py
+++ b/sofagym/ServerEnv.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""ServerEnv to use the server-client architecture.
+"""
+
+__authors__ = ("PSC", "dmarchal", "emenager")
+__contact__ = ("pierre.schegg@robocath.com", "damien.marchal@univ-lille.fr", "etienne.menager@ens-rennes.fr")
+__version__ = "1.0.0"
+__copyright__ = "(c) 2020, Robocath, CNRS, Inria"
+__date__ = "Oct 7 2020"
+
+from typing import Optional
+
+import numpy as np
+import copy
+
+import splib3
+
+from sofagym.rpc_server import start_server, add_new_step, get_result, clean_registry, close_scene
+
+from sofagym.AbstractEnv import AbstractEnv
+
+
+class ServerEnv(AbstractEnv):
+    def __init__(self, default_config, config=None, render_mode: Optional[str]=None, root=None):
+        super().__init__(default_config, config, root=root)
+        
+        # Start the server which distributes the calculations to its clients
+        start_server(self.config)
+
+    def step(self, action):
+        """Executes one action in the environment.
+
+        Apply action and execute scale_factor simulation steps of 0.01 s.
+
+        Parameters:
+        ----------
+            action: int
+                Action applied in the environment.
+
+        Returns:
+        -------
+            obs(ObsType):
+                The new state of the agent.
+            reward(float):
+                The reward obtain after applying the action in the current state.
+            done(bool):
+                Whether the agent reaches the terminal state
+            info(dict): 
+                additional information (not used here)
+        """
+        # assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
+
+        action = self._formataction(action)
+
+        # Pass the actions to the server to launch the simulation.
+        result_id = add_new_step(self.past_actions, action)
+        self.past_actions.append(action)
+
+        # Request results from the server.
+        # print("[INFO]   >>> Result id:", result_id)
+        results = get_result(result_id, timeout=self.timeout)
+
+        obs = np.array(results["observation"])  # to work with baseline
+        reward = results["reward"]
+        done = results["done"]
+
+        # Avoid long explorations by using a timer.
+        self.timer += 1
+        if self.timer >= self.config["timer_limit"]:
+            # reward = -150
+            truncated = True
+        
+        info = {} #(not use here)
+
+        if self.config["planning"]:
+            self.clean()
+        return obs, reward, done, info
+    
+    def async_step(self, action):
+        """Executes one action in the environment.
+
+        Apply action and execute scale_factor simulation steps of 0.01 s.
+        Like step but useful if you want to parallelise (blocking "get").
+        Otherwise use step.
+
+        Parameters:
+        ----------
+            action: int
+                Action applied in the environment.
+
+        Returns:
+        -------
+            LateResult:
+                Class which allows to store the id of the client who performs
+                the calculation and to return later the usual information
+                (observation, reward, done) thanks to a get method.
+
+        """
+        assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
+
+        result_id = add_new_step(self.past_actions, action)
+        self.past_actions.append(action)
+
+        class LateResult:
+            def __init__(self, result_id):
+                self.result_id = result_id
+
+            def get(self, timeout=None):
+                results = get_result(self.result_id, timeout=timeout)
+                obs = results["observation"]
+                reward = results["reward"]
+                done = results["done"]
+                return obs, reward, done, {}
+
+        return LateResult(copy.copy(result_id))
+    
+    def reset(self):
+        """Reset simulation.
+
+        Parameters:
+        ----------
+            None.
+
+        Returns:
+        -------
+            obs, info
+        """
+        self.clean()
+        self.viewer = None
+
+        splib3.animation.animate.manager = None
+
+        self.timer = 0
+        self.past_actions = []
+
+        return
+    
+    def clean(self):
+        """Function to clean the registery .
+
+        Close clients who are processing unused sequences of actions (for
+        planning)
+
+        Parameters:
+        ----------
+            None.
+
+        Returns:
+        -------
+            None.
+        """
+        clean_registry(self.past_actions)
+
+    def close(self):
+        """Terminate simulation.
+
+        Close the viewer and the scene.
+
+        Parametres:
+        ----------
+            None.
+
+        Returns:
+        -------
+            None.
+        """
+        super().close()
+        close_scene()

--- a/sofagym/envs/CartPole/CartPoleEnv.py
+++ b/sofagym/envs/CartPole/CartPoleEnv.py
@@ -1,26 +1,28 @@
 import math
 import os
 import sys
+from typing import Optional
 
 import numpy as np
 from gym import spaces
-from sofagym.AbstractEnv import AbstractEnv
+from sofagym.AbstractEnv import AbstractEnv, ServerEnv
 from sofagym.rpc_server import start_scene
 
 
-class CartPoleEnv(AbstractEnv):
+class CartPoleEnv:
     """Sub-class of AbstractEnv, dedicated to the cart pole scene.
 
     See the class AbstractEnv for arguments and methods.
     """
     #Setting a default configuration
-    path = path = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.dirname(os.path.abspath(__file__))
     metadata = {'render.modes': ['human', 'rgb_array']}
+    dim_state = 4
     DEFAULT_CONFIG = {"scene": "CartPole",
                       "deterministic": True,
                       "source": [0, 0, 160],
                       "target": [0, 0, 0],
-                      "goalList": [[0]],
+                      "goal": False,
                       "start_node": None,
                       "scale_factor": 10,
                       "dt": 0.001,
@@ -38,16 +40,31 @@ class CartPoleEnv(AbstractEnv):
                       "zFar": 4000,
                       "time_before_start": 0,
                       "seed": None,
+                      "nb_actions": 2,
+                      "dim_state": dim_state,
                       "init_x": 0,
-                      "max_move": 24,
+                      "x_threshold": 100,
+                      "max_move": 12,
+                      "max_angle": 0.418,
+                      "randomize_states": True,
+                      "init_states": [0] * dim_state,
+                      "use_server": False
                       }
 
-    def __init__(self, config=None):
-        super().__init__(config)
+    def __init__(self, config = None, root=None, use_server: Optional[bool]=None):
+        if use_server is not None:
+            self.DEFAULT_CONFIG.update({'use_server': use_server})
+        self.use_server = self.DEFAULT_CONFIG["use_server"]
+        self.env = ServerEnv(self.DEFAULT_CONFIG, config, root=root) if self.use_server else AbstractEnv(self.DEFAULT_CONFIG, config, root=root)
 
-        self.x_threshold = 100
-        self.theta_threshold_radians = self.config["max_move"] * math.pi / 180
-        self.config.update({'max_angle': self.theta_threshold_radians})
+        self.initialize_states()
+
+        if self.env.config["goal"]:
+            self.init_goal()
+
+        self.x_threshold = self.env.config["x_threshold"]
+        self.theta_threshold_radians = self.env.config["max_move"] * math.pi / 180
+        self.env.config.update({'max_angle': self.theta_threshold_radians})
         
         high = np.array(
             [
@@ -59,38 +76,56 @@ class CartPoleEnv(AbstractEnv):
             dtype=np.float32,
         )
 
-        nb_actions = 2
-        self.action_space = spaces.Discrete(nb_actions)
-        self.nb_actions = str(nb_actions)
+        self.env.action_space = spaces.Discrete(self.env.nb_actions)
+        self.nb_actions = str(self.env.nb_actions)
 
-        self.observation_space = spaces.Box(-high, high, dtype=np.float32)
+        self.env.observation_space = spaces.Box(-high, high, dtype=np.float32)
 
-    def reset(self):
-        """Reset simulation.
+        if self.env.root is None and not self.use_server:
+            self.env.init_root()
 
-        Note:
-        ----
-            We launch a client to create the scene. The scene of the program is
-            client_<scene>Env.py.
+    # called when an attribute is not found:
+    def __getattr__(self, name):
+        # assume it is implemented by self.instance
+        return self.env.__getattribute__(name)
 
-        """
-        super().reset()
-
-        self.config.update({'goalPos': self.goal})
-        init_states = self.np_random.uniform(low=-0.05, high=0.05, size=(4,))
-        self.config.update({'init_states': list(init_states)})
-        obs = start_scene(self.config, self.nb_actions)
-        return np.array(obs['observation'])
-
-    def get_available_actions(self):
-        """Gives the actions available in the environment.
-
-        Parameters:
-        ----------
-            None.
+    def initialize_states(self):
+        if self.env.config["randomize_states"]:
+            self.init_states = self.randomize_init_states()
+            self.env.config.update({'init_states': list(self.init_states)})
+        else:
+            self.init_states = self.env.config["init_states"]
+    
+    def randomize_init_states(self):
+        """Randomize initial states.
 
         Returns:
         -------
-            list of the action available in the environment.
+            init_states: list
+                List of random initial states for the environment.
+        
+        Note:
+        ----
+            This method should be implemented according to needed random initialization.
         """
-        return self.action_space
+        init_states = self.env.np_random.uniform(low=-0.05, high=0.05, size=(self.env.config["dim_state"],))
+
+        return init_states
+
+    def reset(self):
+        """Reset simulation.
+        """
+        self.initialize_states()
+
+        if self.env.config["goal"]:
+            self.init_goal()
+        
+        self.env.reset()
+        
+        if self.use_server:
+            obs = start_scene(self.env.config, self.nb_actions)
+            state = np.array(obs['observation'], dtype=np.float32)
+        else:
+            state = np.array(self.env._getState(self.env.root), dtype=np.float32)
+        
+        return state

--- a/sofagym/envs/CartPole/CartPoleEnv.py
+++ b/sofagym/envs/CartPole/CartPoleEnv.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import numpy as np
 from gym import spaces
-from sofagym.AbstractEnv import AbstractEnv, ServerEnv
+from sofagym.AbstractEnv import AbstractEnv
+from sofagym.ServerEnv import ServerEnv
 from sofagym.rpc_server import start_scene
 
 

--- a/sofagym/envs/CartPole/CartPoleScene.py
+++ b/sofagym/envs/CartPole/CartPoleScene.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute())+"/../")
 sys.path.insert(0, str(pathlib.Path(__file__).parent.absolute()))
 
-from CartPoleToolbox import ApplyAction, GoalSetter, RewardShaper, StateInitializer
+from CartPoleToolbox import ApplyAction, RewardShaper, StateInitializer
 from sofagym.header import addVisu
 from splib3.animation import AnimationManagerController
 from stlib3.physics.rigid import Floor
@@ -48,16 +48,16 @@ def addRigidObject(node, filename, collisionFilename=None, position=[0, 0, 0, 0,
     return object
 
 
-def createScene(root, 
+def createScene(root,
                 config={"source": [0, 0, 160],
                         "target": [0, 0, 0],
-                        "goalPos": None,
                         "seed": None,
                         "zFar":4000,
                         "init_x": 0,
                         "max_move": 24,
                         "max_angle": 0.418,
-                        "dt": 0.01},
+                        "dt": 0.01,
+                        "init_states": [0]*4},
                 mode='simu_and_visu'):
     
     # Choose the mode: visualization or computations (or both)
@@ -167,5 +167,4 @@ def createScene(root,
     # SofaGym Env Components
     root.addObject(StateInitializer(name="StateInitializer", rootNode=root, pole_length=pole_length, init_states=config['init_states']))
     root.addObject(RewardShaper(name="Reward", rootNode=root, max_angle=config['max_angle'], pole_length=pole_length))
-    root.addObject(GoalSetter(name="GoalSetter"))
     root.addObject(ApplyAction(name="ApplyAction", root=root))

--- a/sofagym/simulate.py
+++ b/sofagym/simulate.py
@@ -61,12 +61,6 @@ def init_simulation(config, _startCmd=None, mode="simu_and_visu"):
         config.update({'render': render})
         print(">>   ... Done.")
 
-    # Init Reward and GoalSetter
-    if config["goal"]:
-        root.GoalSetter.update(config['goalPos'])
-    
-    root.Reward.update(0)
-
     if config["randomize_states"]:
         root.StateInitializer.init_state(config["init_states"])
 
@@ -76,12 +70,12 @@ def init_simulation(config, _startCmd=None, mode="simu_and_visu"):
             Sofa.Simulation.animate(root, config["dt"])
         print(">>   ... Done.")
         
-        # Update Reward and GoalSetter
-        if config["goal"]:
-            root.GoalSetter.update(config['goalPos'])
-            root.Reward.update(config['goalPos'])
-        else:
-            root.Reward.update()
+    # Update Reward and GoalSetter
+    if config["goal"]:
+        root.GoalSetter.update(config['goalPos'])
+        root.Reward.update(config['goalPos'])
+    else:
+        root.Reward.update()
 
     return root
 

--- a/sofagym/simulate.py
+++ b/sofagym/simulate.py
@@ -67,10 +67,8 @@ def init_simulation(config, _startCmd=None, mode="simu_and_visu"):
     
     root.Reward.update(0)
 
-    try:
+    if config["randomize_states"]:
         root.StateInitializer.init_state(config["init_states"])
-    except AttributeError as error:
-        print(error)
 
     if 'time_before_start' in config:
         print(">>   Time before start:", config["time_before_start"], "steps. Initialization ...")

--- a/sofagym/simulate.py
+++ b/sofagym/simulate.py
@@ -62,11 +62,13 @@ def init_simulation(config, _startCmd=None, mode="simu_and_visu"):
         print(">>   ... Done.")
 
     # Init Reward and GoalSetter
-    root.GoalSetter.update()
-    root.Reward.update()
+    if config["goal"]:
+        root.GoalSetter.update(config['goalPos'])
+    
+    root.Reward.update(0)
 
     try:
-        root.StateInitializer.init_state()
+        root.StateInitializer.init_state(config["init_states"])
     except AttributeError as error:
         print(error)
 
@@ -75,9 +77,13 @@ def init_simulation(config, _startCmd=None, mode="simu_and_visu"):
         for i in range(config["time_before_start"]):
             Sofa.Simulation.animate(root, config["dt"])
         print(">>   ... Done.")
+        
         # Update Reward and GoalSetter
-        root.GoalSetter.update()
-        root.Reward.update()
+        if config["goal"]:
+            root.GoalSetter.update(config['goalPos'])
+            root.Reward.update(config['goalPos'])
+        else:
+            root.Reward.update()
 
     return root
 
@@ -106,11 +112,13 @@ def step_simulation(root, config, action, _startCmd, _getPos, viewer=None):
             The positions of object(s) in the scene.
 
     """
-    goal = config['goalPos']
+    if config["goal"]:
+        goal = config['goalPos']
+        root.GoalSetter.set_mo_pos(goal)
+    
     render = config['render']
     surface_size = config['display_size']
 
-    root.GoalSetter.set_mo_pos(goal)
 
     # Create the command from action
     _startCmd(root, action, config["dt"]*(config["scale_factor"]-1))

--- a/sofagym/viewer.py
+++ b/sofagym/viewer.py
@@ -62,7 +62,7 @@ class Viewer:
 
     """
 
-    def __init__(self, env, surface_size, zFar=100, save_path=None, create_video=None, fps=10):
+    def __init__(self, env, root, surface_size, zFar=100, save_path=None, create_video=None, fps=10):
         """
         Classic initialization of a class in python.
 
@@ -97,7 +97,11 @@ class Viewer:
         self.agent_display = None
         self.frame = 0
 
-        self.root = init_simulation(self.env.config, mode = 'visu')
+        if self.env.config["use_server"]:
+            self.root = init_simulation(self.env.config, mode = 'visu')
+        else:
+            self.root = root
+        
         scene = self.env.config['scene']
         self._setPos = importlib.import_module("sofagym.envs."+scene+"."+scene+"Toolbox").setPos
 
@@ -132,15 +136,21 @@ class Viewer:
         # Recovering an image and handling error cases
         try:
             if pos is None:
-                pos = get_position(self.env.past_actions)['position']
+                if self.env.config["use_server"]:
+                    pos = get_position(self.env.past_actions)['position']
+                else:
+                    pos = self.env.pos
+            
             self.frame += 1
+            
             if pos == []:
                 image = np.zeros((self.surface_size[0], self.surface_size[1], 3))
             else:
                 num_im = 0
                 for p in pos:
-                    self._setPos(self.root, p)
-                    Sofa.Simulation.animate(self.root, self.root.getDt())
+                    if self.env.config["use_server"]:
+                        self._setPos(self.root, p)
+                        Sofa.Simulation.animate(self.root, self.root.getDt())
 
                     glViewport(0, 0, self.surface_size[0], self.surface_size[1])
 


### PR DESCRIPTION
Added a new implementation to the `AbstractEnv` class that works without the need for the server-client architecture
- The `AbstractEnv` class is now split used for the no-server implementation
- `The `ServerEnv` class inherits from the `AbstractEnv` class and implements the server-client architecture
- Both implementations could be used with any environment by setting the `bool` flag `use_server` in the default configs of each environment. It's `false` by default for all environments currently provided in SofaGym to have the no-server implementation as the default one.
- Included the `Cartpole` env as a working example of the new implementations with the necessary changes to the environments.
- Cleaned some parts relating to the initialization and randomization of the env states and goal by adding new methods `initialize_states`, `randomize_init_states`, and `init_goal` that could be overridden in the env class to implement specific initializations if needed.